### PR TITLE
RHEL/CentOS Stream qemu-kvm compatibility, improve Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,13 +2,9 @@ FROM registry.fedoraproject.org/fedora:38
 
 COPY slp-qemu-android-fedora-38.repo /etc/yum.repos.d/slp-qemu-android-fedora-38.repo
 
-RUN dnf install -y qemu-system-x86 qemu-system-aarch64 virglrenderer rust-vhost-user-vsock
-RUN mkdir -p /opt/start-avm/templates
+RUN dnf install -y qemu-system-x86 qemu-system-aarch64 virglrenderer vhost-user-vsock cvd2img openssl
 
-COPY run_start_avm.sh /run_start_avm.sh
-COPY start_cvd_tools /opt/start-avm/start_cvd_tools
-COPY start_avm.sh /opt/start-avm/start_avm.sh
-COPY templates/.cuttlefish_config.json /opt/start-avm/templates
+COPY run_start_avm.sh start_cvd_tools start_avm.sh /opt/start-avm/
+COPY templates /opt/start-avm/templates/
 
-CMD ["/bin/bash", "/run_start_avm.sh"]
-
+CMD ["/bin/bash", "/opt/start-avm/run_start_avm.sh"]

--- a/start_avm.sh
+++ b/start_avm.sh
@@ -56,7 +56,7 @@ else
     NETWORK="-netdev user,id=hostnet0"
 fi
 if [ $VHOST_USER == 1 ]; then
-    /usr/libexec/vhost-user-vsock --socket ${CVD_BASE_DIR}/qemu/vhost-user-vsock.sock --uds-path ${CVD_BASE_DIR}/qemu/vhost-user-vsock.uds &
+    /usr/bin/vhost-user-vsock --socket ${CVD_BASE_DIR}/qemu/vhost-user-vsock.sock --uds-path ${CVD_BASE_DIR}/qemu/vhost-user-vsock.uds &
     CVD_TOOLS_OPTS="$CVD_TOOLS_OPTS -u"
     VSOCK="-chardev socket,id=char0,reconnect=0,path=${CVD_BASE_DIR}/qemu/vhost-user-vsock.sock -device vhost-user-vsock-pci,chardev=char0"
 else


### PR DESCRIPTION
RHEL's qemu-kvm has different features, let's use them as a fallback if
optimal devices are not available.
Fallback for gtk UI to suboptimal, but functional egl-headless with VNC
remote access.
Fallback for sound card AC97 to ich9-intel-hda.
