### PR TITLE
Prefer using the dbus backend by default

### DIFF
--- a/start_avm.sh
+++ b/start_avm.sh
@@ -86,7 +86,9 @@ if [ ! -x ${QEMU} ]; then
     QEMU=qemu-system-${ARCH}
 fi
 
-if ${QEMU} -display ? | grep -q gtk; then
+if ${QEMU} -display ? | grep -q dbus; then
+    UI="dbus"
+elif ${QEMU} -display ? | grep -q gtk; then
     UI="gtk"
 else
     UI="egl-headless -vnc :0"


### PR DESCRIPTION
That would make the experience of running it with libmks/snowglobe much simpler and without having to modify the script manually