### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the built binary file
+**/start_cvd_tools


### PR DESCRIPTION
Create .gitignore file in order to avoid the
compiled binary file to appear in git status.