### PR TITLE
Make bash shebang portable

### DIFF
--- a/run_podman.sh
+++ b/run_podman.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VIRGL=0
 MT=0

--- a/start_avm.sh
+++ b/start_avm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CONFIG_SERVER=0
 VHOST_USER=0


### PR DESCRIPTION
Not every system has /usr/bin/bash, let's use /usr/bin/env to determine the right bash path.